### PR TITLE
New data model & semantic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paf-mvp-frontend",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "description": "Prebid Addressability Framework (PAF) frontend library and widget",
   "main": "src/main.tsx",
   "scripts": {
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/criteo/paf-mvp-frontend#readme",
   "dependencies": {
     "@preact/compat": "^17.0.3",
-    "paf-mvp-core-js": "criteo/paf-mvp-core-js#semver:0.1.1",
+    "paf-mvp-core-js": "criteo/paf-mvp-core-js#semver:0.1.4",
     "preact": "^10.5.15",
     "preact-habitat": "^3.3.0",
     "ua-parser-js": "^1.0.2"

--- a/src/lib/paf-lib.ts
+++ b/src/lib/paf-lib.ts
@@ -1,12 +1,17 @@
 import UAParser from "ua-parser-js";
 import {
-    GetIdsPrefsResponse,
-    IdsAndOptionalPreferences,
-    IdsAndPreferences,
-    PostIdsPrefsRequest,
-    Preferences
+  GetIdsPrefsResponse,
+  IdsAndOptionalPreferences,
+  IdsAndPreferences,
+  PostIdsPrefsRequest,
+  Preferences
 } from "paf-mvp-core-js/dist/model/generated-model";
-import {Cookies, fromCookieValues, getPrebidDataCacheExpiration, UNKNOWN_TO_OPERATOR} from "paf-mvp-core-js/dist/cookies";
+import {
+  Cookies,
+  fromCookieValues,
+  getPrebidDataCacheExpiration,
+  UNKNOWN_TO_OPERATOR
+} from "paf-mvp-core-js/dist/cookies";
 import {NewPrefs} from "paf-mvp-core-js/dist/model/model";
 import {jsonEndpoints, redirectEndpoints, signAndVerifyEndpoints, uriParams} from "paf-mvp-core-js/dist/endpoints";
 import {isBrowserKnownToSupport3PC} from "paf-mvp-core-js/dist/user-agent";
@@ -14,258 +19,255 @@ import {isBrowserKnownToSupport3PC} from "paf-mvp-core-js/dist/user-agent";
 const logger = console;
 
 const redirect = (url: string): void => {
-    document.location = url;
+  document.location = url;
 }
 
 // Remove any "paf data" param from the query string
 // From https://stackoverflow.com/questions/1634748/how-can-i-delete-a-query-string-parameter-in-javascript/25214672#25214672
 // TODO should be able to use a more standard way, but URL class is immutable :-(
 const removeUrlParameter = (url: string, parameter: string) => {
-    const urlParts = url.split('?');
+  const urlParts = url.split('?');
 
-    if (urlParts.length >= 2) {
-        // Get first part, and remove from array
-        const urlBase = urlParts.shift();
+  if (urlParts.length >= 2) {
+    // Get first part, and remove from array
+    const urlBase = urlParts.shift();
 
-        // Join it back up
-        const queryString = urlParts.join('?');
+    // Join it back up
+    const queryString = urlParts.join('?');
 
-        const prefix = `${encodeURIComponent(parameter)}=`;
-        const parts = queryString.split(/[&;]/g);
+    const prefix = `${encodeURIComponent(parameter)}=`;
+    const parts = queryString.split(/[&;]/g);
 
-        // Reverse iteration as may be destructive
-        for (let i = parts.length; i-- > 0;) {
-            // Idiom for string.startsWith
-            if (parts[i].lastIndexOf(prefix, 0) !== -1) {
-                parts.splice(i, 1);
-            }
-        }
-
-        url = urlBase + (parts.length > 0 ? (`?${parts.join('&')}`) : '');
+    // Reverse iteration as may be destructive
+    for (let i = parts.length; i-- > 0;) {
+      // Idiom for string.startsWith
+      if (parts[i].lastIndexOf(prefix, 0) !== -1) {
+        parts.splice(i, 1);
+      }
     }
 
-    return url;
+    url = urlBase + (parts.length > 0 ? (`?${parts.join('&')}`) : '');
+  }
+
+  return url;
 };
 
 const getCookieValue = (name: string): string => (
-    document.cookie.match(`(^|;)\\s*${name}\\s*=\\s*([^;]+)`)?.pop() || ''
+  document.cookie.match(`(^|;)\\s*${name}\\s*=\\s*([^;]+)`)?.pop() || ''
 )
 
 const setCookie = (name: string, value: string, expiration: Date) => {
-    document.cookie = `${name}=${value};expires=${expiration.toUTCString()}`
+  document.cookie = `${name}=${value};expires=${expiration.toUTCString()}`
 }
 
 // Update the URL shown in the address bar, without Prebid SSO data
 const cleanUpUrL = () => history.pushState(null, "", removeUrlParameter(location.href, uriParams.data));
 
 const getProxyUrl = (proxyBase: string) => (endpoint: string): string => {
-    return `${proxyBase}/prebid${endpoint}`
+  return `${proxyBase}/prebid${endpoint}`
 }
 
 const redirectToProxyRead = (proxyBase: string) => (): void => {
-    const redirectUrl = new URL(getProxyUrl(proxyBase)(redirectEndpoints.read))
-    redirectUrl.searchParams.set(uriParams.returnUrl, location.href)
-    redirect(redirectUrl.toString());
+  const redirectUrl = new URL(getProxyUrl(proxyBase)(redirectEndpoints.read))
+  redirectUrl.searchParams.set(uriParams.returnUrl, location.href)
+  redirect(redirectUrl.toString());
 }
 
-const saveCookieValueOrUnknown = <T>(cookieName: string, cookieValue: T | undefined) : string => {
-    logger.info(`Operator returned value for ${cookieName}: ${cookieValue !== undefined ? 'YES' : 'NO'}`)
+const saveCookieValueOrUnknown = <T>(cookieName: string, cookieValue: T | undefined): string => {
+  logger.info(`Operator returned value for ${cookieName}: ${cookieValue !== undefined ? 'YES' : 'NO'}`)
 
-    const valueToStore = cookieValue ? JSON.stringify(cookieValue) : UNKNOWN_TO_OPERATOR
+  const valueToStore = cookieValue ? JSON.stringify(cookieValue) : UNKNOWN_TO_OPERATOR
 
-    logger.info(`Save ${cookieName} value: ${valueToStore}`)
+  logger.info(`Save ${cookieName} value: ${valueToStore}`)
 
-    setCookie(cookieName, valueToStore, getPrebidDataCacheExpiration())
+  setCookie(cookieName, valueToStore, getPrebidDataCacheExpiration())
 
-    return valueToStore;
+  return valueToStore;
 }
 
 const removeCookie = (cookieName: string) => {
-    setCookie(cookieName, null, new Date(0))
+  setCookie(cookieName, null, new Date(0))
 }
 
 let thirdPartyCookiesSupported: boolean | undefined;
 
 const processGetIdsAndPreferences = async (proxyBase: string): Promise<IdsAndOptionalPreferences | undefined> => {
 
-    const getUrl = getProxyUrl(proxyBase)
-    const redirectToRead = redirectToProxyRead(proxyBase)
+  const getUrl = getProxyUrl(proxyBase)
+  const redirectToRead = redirectToProxyRead(proxyBase)
 
-    // 1. Any Prebid 1st party cookie?
-    const id = getCookieValue(Cookies.ID)
-    const rawPreferences = getCookieValue(Cookies.PREFS)
+  // 1. Any Prebid 1st party cookie?
+  const rawIds = getCookieValue(Cookies.identifiers)
+  const rawPreferences = getCookieValue(Cookies.preferences)
 
-    if (id && rawPreferences) {
-        logger.info('Cookie found: YES')
-        cleanUpUrL();
-
-        return fromCookieValues(id, rawPreferences)
-    }
-
-    logger.info('Cookie found: NO')
-
-    const urlParams = new URLSearchParams(window.location.search);
-    const uriData = urlParams.get(uriParams.data);
-
+  if (rawIds && rawPreferences) {
+    logger.info('Cookie found: YES')
     cleanUpUrL();
 
-    // 2. Redirected from operator?
-    if (uriData) {
-        logger.info('Redirected from operator: YES')
+    return fromCookieValues(rawIds, rawPreferences)
+  }
 
-        // Consider that if we have been redirected, it means 3PC are not supported
-        thirdPartyCookiesSupported = false;
+  logger.info('Cookie found: NO')
 
-        // Verify message
-        const response = await fetch(getUrl(signAndVerifyEndpoints.verifyRead), {
-            method: 'POST',
-            body: uriData,
-            credentials: 'include'
-        })
-        const verificationResult = await response.json() as GetIdsPrefsResponse
+  const urlParams = new URLSearchParams(window.location.search);
+  const uriData = urlParams.get(uriParams.data);
 
-        if (!verificationResult) {
-            throw 'Verification failed'
-        }
+  cleanUpUrL();
 
-        const operatorData = JSON.parse(uriData ?? '{}') as GetIdsPrefsResponse
+  // 2. Redirected from operator?
+  if (uriData) {
+    logger.info('Redirected from operator: YES')
 
-        // 3. Received data?
-        const returnedId = operatorData.body.identifiers?.[0]
-        const hasPersistedId = returnedId?.persisted === undefined || returnedId?.persisted
-        saveCookieValueOrUnknown(Cookies.ID, hasPersistedId ? returnedId : undefined)
-        saveCookieValueOrUnknown(Cookies.PREFS, operatorData.body.preferences)
+    // Consider that if we have been redirected, it means 3PC are not supported
+    thirdPartyCookiesSupported = false;
 
-        return operatorData.body
+    // Verify message
+    const response = await fetch(getUrl(signAndVerifyEndpoints.verifyRead), {
+      method: 'POST',
+      body: uriData,
+      credentials: 'include'
+    })
+    const verificationResult = await response.json() as GetIdsPrefsResponse
+
+    if (!verificationResult) {
+      throw 'Verification failed'
     }
 
-    logger.info('Redirected from operator: NO')
+    const operatorData = JSON.parse(uriData ?? '{}') as GetIdsPrefsResponse
 
-    // 4. Browser known to support 3PC?
-    const userAgent = new UAParser(navigator.userAgent);
+    // 3. Received data?
+    const persistedIds = operatorData.body.identifiers.filter(identifier => identifier?.persisted !== false);
+    saveCookieValueOrUnknown(Cookies.identifiers, persistedIds.length === 0 ? undefined : persistedIds)
+    saveCookieValueOrUnknown(Cookies.preferences, operatorData.body.preferences)
 
-    if (isBrowserKnownToSupport3PC(userAgent.getBrowser())) {
-        logger.info('Browser known to support 3PC: YES')
+    return operatorData.body
+  }
 
-        logger.info('Attempt to read from JSON')
-        const readResponse = await fetch(getUrl(jsonEndpoints.read), {credentials: 'include'})
-        const operatorData = await readResponse.json() as GetIdsPrefsResponse
+  logger.info('Redirected from operator: NO')
 
-        const returnedId = operatorData.body.identifiers?.[0]
-        const hasPersistedId = returnedId?.persisted === undefined || returnedId?.persisted
+  // 4. Browser known to support 3PC?
+  const userAgent = new UAParser(navigator.userAgent);
 
-        // 3. Received data?
-        if (hasPersistedId) {
-            logger.info('Operator returned id & prefs: YES')
+  if (isBrowserKnownToSupport3PC(userAgent.getBrowser())) {
+    logger.info('Browser known to support 3PC: YES')
 
-            // If we got data, it means 3PC are supported
-            thirdPartyCookiesSupported = true;
+    logger.info('Attempt to read from JSON')
+    const readResponse = await fetch(getUrl(jsonEndpoints.read), {credentials: 'include'})
+    const operatorData = await readResponse.json() as GetIdsPrefsResponse
 
-            // /!\ Note: we don't need to verify the message here as it is a REST call
+    const persistedIds = operatorData.body.identifiers.filter(identifier => identifier?.persisted !== false);
 
-            saveCookieValueOrUnknown(Cookies.ID, hasPersistedId ? returnedId : undefined)
-            saveCookieValueOrUnknown(Cookies.PREFS, operatorData.body.preferences)
+    // 3. Received data?
+    if (persistedIds) {
+      logger.info('Operator returned id & prefs: YES')
 
-            return operatorData.body
-        }
-        logger.info('Operator returned id & prefs: NO')
+      // If we got data, it means 3PC are supported
+      thirdPartyCookiesSupported = true;
 
-        logger.info('Verify 3PC on operator')
-        // Note: need to include credentials to make sure cookies are sent
-        const verifyResponse = await fetch(getUrl(jsonEndpoints.verify3PC), {credentials: 'include'})
-        const testOk = await verifyResponse.json()
+      // /!\ Note: we don't need to verify the message here as it is a REST call
 
-        // 4. 3d party cookie ok?
-        if (testOk) {
-            logger.info('3PC verification OK: YES')
+      saveCookieValueOrUnknown(Cookies.identifiers, persistedIds)
+      saveCookieValueOrUnknown(Cookies.preferences, operatorData.body.preferences)
 
-            thirdPartyCookiesSupported = true;
-
-            logger.info('Save "unknown"')
-            setCookie(Cookies.ID, UNKNOWN_TO_OPERATOR, getPrebidDataCacheExpiration())
-            setCookie(Cookies.PREFS, UNKNOWN_TO_OPERATOR, getPrebidDataCacheExpiration())
-
-            return {identifiers: [returnedId]}
-        }
-        logger.info('3PC verification OK: NO')
-        thirdPartyCookiesSupported = false;
-        logger.info('Fallback to JS redirect')
-    } else {
-        logger.info('Browser known to support 3PC: NO')
-        thirdPartyCookiesSupported = false;
-        logger.info('JS redirect')
+      return operatorData.body
     }
+    logger.info('Operator returned id & prefs: NO')
+
+    logger.info('Verify 3PC on operator')
+    // Note: need to include credentials to make sure cookies are sent
+    const verifyResponse = await fetch(getUrl(jsonEndpoints.verify3PC), {credentials: 'include'})
+    const testOk = await verifyResponse.json()
+
+    // 4. 3d party cookie ok?
+    if (testOk) {
+      logger.info('3PC verification OK: YES')
+
+      thirdPartyCookiesSupported = true;
+
+      logger.info('Save "unknown"')
+      setCookie(Cookies.identifiers, UNKNOWN_TO_OPERATOR, getPrebidDataCacheExpiration())
+      setCookie(Cookies.preferences, UNKNOWN_TO_OPERATOR, getPrebidDataCacheExpiration())
+
+      return {identifiers: operatorData.body.identifiers}
+    }
+    logger.info('3PC verification OK: NO')
+    thirdPartyCookiesSupported = false;
+    logger.info('Fallback to JS redirect')
+  } else {
+    logger.info('Browser known to support 3PC: NO')
+    thirdPartyCookiesSupported = false;
+    logger.info('JS redirect')
+  }
   redirectToRead()
 };
 
 const processWriteIdsAndPref = async (proxyBase: string, unsignedRequest: IdsAndPreferences): Promise<IdsAndOptionalPreferences | undefined> => {
-    const getUrl = getProxyUrl(proxyBase)
+  const getUrl = getProxyUrl(proxyBase)
 
-    // First clean up local cookies
-    removeCookie(Cookies.ID)
-    removeCookie(Cookies.PREFS)
+  // First clean up local cookies
+  removeCookie(Cookies.identifiers)
+  removeCookie(Cookies.preferences)
 
-    // FIXME this boolean will be up to date only if a read occurred just before. If not, would need to explicitly test
-    if (thirdPartyCookiesSupported) {
-        // 1) sign the request
-        const signedResponse = await fetch(getUrl(signAndVerifyEndpoints.signWrite), {
-            method: 'POST',
-            body: JSON.stringify(unsignedRequest),
-            credentials: 'include'
-        })
-        const signedData = await signedResponse.json() as PostIdsPrefsRequest
+  // FIXME this boolean will be up to date only if a read occurred just before. If not, would need to explicitly test
+  if (thirdPartyCookiesSupported) {
+    // 1) sign the request
+    const signedResponse = await fetch(getUrl(signAndVerifyEndpoints.signWrite), {
+      method: 'POST',
+      body: JSON.stringify(unsignedRequest),
+      credentials: 'include'
+    })
+    const signedData = await signedResponse.json() as PostIdsPrefsRequest
 
-        // 2) send
-        const response = await fetch(getUrl(jsonEndpoints.write), {
-            method: 'POST',
-            body: JSON.stringify(signedData),
-            credentials: 'include'
-        })
-        const operatorData = await response.json() as GetIdsPrefsResponse
+    // 2) send
+    const response = await fetch(getUrl(jsonEndpoints.write), {
+      method: 'POST',
+      body: JSON.stringify(signedData),
+      credentials: 'include'
+    })
+    const operatorData = await response.json() as GetIdsPrefsResponse
 
-        const returnedId = operatorData.body.identifiers?.[0]
-        const hasPersistedId = returnedId?.persisted === undefined || returnedId?.persisted
+    const persistedIds = operatorData.body.identifiers.filter(identifier => identifier?.persisted !== false);
 
-        saveCookieValueOrUnknown(Cookies.ID, hasPersistedId ? returnedId : undefined);
-        saveCookieValueOrUnknown(Cookies.PREFS, operatorData.body.preferences);
+    saveCookieValueOrUnknown(Cookies.identifiers, persistedIds.length === 0 ? undefined : persistedIds)
+    saveCookieValueOrUnknown(Cookies.preferences, operatorData.body.preferences);
 
-        return operatorData.body
+    return operatorData.body
 
-    }
-    // Redirect. Signing of the request will happen on the backend proxy
-    const redirectUrl = new URL(getUrl(redirectEndpoints.write))
-    redirectUrl.searchParams.set(uriParams.returnUrl, location.href)
-    redirectUrl.searchParams.set(uriParams.data, JSON.stringify(unsignedRequest))
+  }
+  // Redirect. Signing of the request will happen on the backend proxy
+  const redirectUrl = new URL(getUrl(redirectEndpoints.write))
+  redirectUrl.searchParams.set(uriParams.returnUrl, location.href)
+  redirectUrl.searchParams.set(uriParams.data, JSON.stringify(unsignedRequest))
 
-    redirect(redirectUrl.toString());
+  redirect(redirectUrl.toString());
 }
 
 /**
  * @param proxyBase ex: http://myproxy.com
  */
 export const getIdsAndPreferences = async (proxyBase: string): Promise<IdsAndOptionalPreferences | undefined> => {
-    const idsAndPreferences = await processGetIdsAndPreferences(proxyBase);
+  const idsAndPreferences = await processGetIdsAndPreferences(proxyBase);
 
-    logger.info('Finished', idsAndPreferences)
+  logger.info('Finished', idsAndPreferences)
 
-    return idsAndPreferences;
+  return idsAndPreferences;
 }
 
 export const writeIdsAndPref = async (proxyBase: string, input: IdsAndPreferences): Promise<IdsAndOptionalPreferences | undefined> => {
-    const idsAndPreferences = await processWriteIdsAndPref(proxyBase, input);
+  const idsAndPreferences = await processWriteIdsAndPref(proxyBase, input);
 
-    logger.info('Finished', idsAndPreferences)
+  logger.info('Finished', idsAndPreferences)
 
-    return idsAndPreferences;
+  return idsAndPreferences;
 }
 
 export const signPreferences = async (proxyBase: string, input: NewPrefs): Promise<Preferences> => {
-    const getUrl = getProxyUrl(proxyBase)
+  const getUrl = getProxyUrl(proxyBase)
 
-    const signedResponse = await fetch(getUrl(signAndVerifyEndpoints.signPrefs), {
-        method: 'POST',
-        body: JSON.stringify(input),
-        credentials: 'include'
-    })
-    return await signedResponse.json() as Preferences
+  const signedResponse = await fetch(getUrl(signAndVerifyEndpoints.signPrefs), {
+    method: 'POST',
+    body: JSON.stringify(input),
+    credentials: 'include'
+  })
+  return await signedResponse.json() as Preferences
 }

--- a/src/lib/paf-lib.ts
+++ b/src/lib/paf-lib.ts
@@ -1,9 +1,9 @@
 import UAParser from "ua-parser-js";
 import {
-    GetIdPrefsResponse,
-    IdAndOptionalPreferences,
-    IdAndPreferences,
-    PostIdPrefsRequest,
+    GetIdsPrefsResponse,
+    IdsAndOptionalPreferences,
+    IdsAndPreferences,
+    PostIdsPrefsRequest,
     Preferences
 } from "paf-mvp-core-js/dist/model/generated-model";
 import {Cookies, fromCookieValues, getPrebidDataCacheExpiration, UNKNOWN_TO_OPERATOR} from "paf-mvp-core-js/dist/cookies";
@@ -86,7 +86,7 @@ const removeCookie = (cookieName: string) => {
 
 let thirdPartyCookiesSupported: boolean | undefined;
 
-const processGetIdAndPreferences = async (proxyBase: string): Promise<IdAndOptionalPreferences | undefined> => {
+const processGetIdsAndPreferences = async (proxyBase: string): Promise<IdsAndOptionalPreferences | undefined> => {
 
     const getUrl = getProxyUrl(proxyBase)
     const redirectToRead = redirectToProxyRead(proxyBase)
@@ -122,13 +122,13 @@ const processGetIdAndPreferences = async (proxyBase: string): Promise<IdAndOptio
             body: uriData,
             credentials: 'include'
         })
-        const verificationResult = await response.json() as GetIdPrefsResponse
+        const verificationResult = await response.json() as GetIdsPrefsResponse
 
         if (!verificationResult) {
             throw 'Verification failed'
         }
 
-        const operatorData = JSON.parse(uriData ?? '{}') as GetIdPrefsResponse
+        const operatorData = JSON.parse(uriData ?? '{}') as GetIdsPrefsResponse
 
         // 3. Received data?
         const returnedId = operatorData.body.identifiers?.[0]
@@ -149,7 +149,7 @@ const processGetIdAndPreferences = async (proxyBase: string): Promise<IdAndOptio
 
         logger.info('Attempt to read from JSON')
         const readResponse = await fetch(getUrl(jsonEndpoints.read), {credentials: 'include'})
-        const operatorData = await readResponse.json() as GetIdPrefsResponse
+        const operatorData = await readResponse.json() as GetIdsPrefsResponse
 
         const returnedId = operatorData.body.identifiers?.[0]
         const hasPersistedId = returnedId?.persisted === undefined || returnedId?.persisted
@@ -198,7 +198,7 @@ const processGetIdAndPreferences = async (proxyBase: string): Promise<IdAndOptio
   redirectToRead()
 };
 
-const processWriteIdAndPref = async (proxyBase: string, unsignedRequest: IdAndPreferences): Promise<IdAndOptionalPreferences | undefined> => {
+const processWriteIdsAndPref = async (proxyBase: string, unsignedRequest: IdsAndPreferences): Promise<IdsAndOptionalPreferences | undefined> => {
     const getUrl = getProxyUrl(proxyBase)
 
     // First clean up local cookies
@@ -213,7 +213,7 @@ const processWriteIdAndPref = async (proxyBase: string, unsignedRequest: IdAndPr
             body: JSON.stringify(unsignedRequest),
             credentials: 'include'
         })
-        const signedData = await signedResponse.json() as PostIdPrefsRequest
+        const signedData = await signedResponse.json() as PostIdsPrefsRequest
 
         // 2) send
         const response = await fetch(getUrl(jsonEndpoints.write), {
@@ -221,7 +221,7 @@ const processWriteIdAndPref = async (proxyBase: string, unsignedRequest: IdAndPr
             body: JSON.stringify(signedData),
             credentials: 'include'
         })
-        const operatorData = await response.json() as GetIdPrefsResponse
+        const operatorData = await response.json() as GetIdsPrefsResponse
 
         const returnedId = operatorData.body.identifiers?.[0]
         const hasPersistedId = returnedId?.persisted === undefined || returnedId?.persisted
@@ -243,20 +243,20 @@ const processWriteIdAndPref = async (proxyBase: string, unsignedRequest: IdAndPr
 /**
  * @param proxyBase ex: http://myproxy.com
  */
-export const getIdAndPreferences = async (proxyBase: string): Promise<IdAndOptionalPreferences | undefined> => {
-    const idAndPreferences = await processGetIdAndPreferences(proxyBase);
+export const getIdsAndPreferences = async (proxyBase: string): Promise<IdsAndOptionalPreferences | undefined> => {
+    const idsAndPreferences = await processGetIdsAndPreferences(proxyBase);
 
-    logger.info('Finished', idAndPreferences)
+    logger.info('Finished', idsAndPreferences)
 
-    return idAndPreferences;
+    return idsAndPreferences;
 }
 
-export const writeIdAndPref = async (proxyBase: string, input: IdAndPreferences): Promise<IdAndOptionalPreferences | undefined> => {
-    const idAndPreferences = await processWriteIdAndPref(proxyBase, input);
+export const writeIdsAndPref = async (proxyBase: string, input: IdsAndPreferences): Promise<IdsAndOptionalPreferences | undefined> => {
+    const idsAndPreferences = await processWriteIdsAndPref(proxyBase, input);
 
-    logger.info('Finished', idAndPreferences)
+    logger.info('Finished', idsAndPreferences)
 
-    return idAndPreferences;
+    return idsAndPreferences;
 }
 
 export const signPreferences = async (proxyBase: string, input: NewPrefs): Promise<Preferences> => {


### PR DESCRIPTION
- use new format for query strings (use a single `paf` parameter)
- all messages renamed from `Id` to `Ids` (because it's _a list_ of identifiers)
- renamed all cookies
- use new semantic for REST & redirect endpoints
- use Request and Response _builders_
- introduce error handling (more to come)